### PR TITLE
fix: build with kody protobuf 2.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    id("kodypay.protobuf") version "2.0.0"
+    id("kodypay.protobuf") version "2.3.1"
 }
 apply(plugin = "kodypay.protobuf-grpc")
 group = "com.kodypay.api.grpc"
 kodypay {
     javaSources = true
-    jvmTarget = "21"
+    jvmTarget = "11"
     releaseStrategy = com.kodypay.plugin.release.KodypayStrategies.KP_DEFAULT
 }
 repositories { mavenCentral() }


### PR DESCRIPTION
## **Associated JIRA tasks**

.

## **What the code does.**

Build with kody protobuf 2.3.1 which upgrades the google protobuf dependency.
Also downgrade java version to 11 to match other repos

## **Does this code change break backwards compatibility?.**

Hopefully not!