### PR TITLE
fix: update details API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+build/
+.gradle/

--- a/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
+++ b/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
@@ -92,6 +92,7 @@ message PaymentDetailsResponse {
     enum Type {
       UNKNOWN = 0;
       NOT_FOUND = 1;
+      INVALID_REQUEST = 2;
     }
   }
 

--- a/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
+++ b/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
@@ -75,7 +75,7 @@ message PaymentDetailsResponse {
     optional string payment_data_json = 6; // json blob containing payment data
 
     google.protobuf.Timestamp date_created = 7;
-    google.protobuf.Timestamp date_paid = 8;
+    optional google.protobuf.Timestamp date_paid = 8;
 
     enum PaymentStatus {
       PENDING = 0;


### PR DESCRIPTION
The PaymentDetail can be unpaid (any non paid status). In thuis scenarion the date_paid is not set hence the server can't retrieve it
Also the incoming request can be invalid if any field is blank, hence we need to add the relevant value to the error enum