### PR TITLE
feat: Expand integrated payment status to include expired

### DIFF
--- a/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
+++ b/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
@@ -94,6 +94,7 @@ message PaymentDetailsResponse {
       SUCCESS = 1;
       FAILED = 2;
       CANCELLED = 3;
+      EXPIRED = 4;
     }
   }
 }
@@ -134,6 +135,7 @@ message GetPaymentsResponse {
         SUCCESS = 1;
         FAILED = 2;
         CANCELLED = 3;
+        EXPIRED = 4;
       }
     }
   }


### PR DESCRIPTION
Payment links can expire. This change expands the integrated payments API to make it clear when this is the case. 