### PR TITLE
BAM-549: return adjustments in get preauth response

### DIFF
--- a/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
+++ b/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
@@ -141,7 +141,7 @@ message TopUpAuthorisationRequest {
 message TopUpAuthorisationResponse {
   string top_up_reference = 1; // Echoed from request.
   string psp_reference = 2;
-  optional string order_id = 3; // Echoed from reqeust.
+  optional string order_id = 3; // Echoed from request.
 
   // The new total amount authorised on the card after the top-up.
   optional uint64 total_authorised_amount_minor_units = 4;
@@ -251,6 +251,9 @@ message GetPreAuthorisationResponse {
 
   // The timestamp of when the payment is successfully authorised.
   optional google.protobuf.Timestamp authorised_at = 13;
+
+  // Any adjustments made to this pre-authorisation.
+  repeated Adjustment adjustments = 14;
 }
 
 // --- Supporting Messages ---
@@ -293,4 +296,18 @@ message PaymentCard {
 enum PaymentMethodType {
   CARD_PRESENT = 0;
   MOTO = 1; // Mail Order / Telephone Order
+}
+
+message Adjustment {
+  string adjustment_id = 1;
+  optional string adjustment_reference = 2;
+  AdjustmentStatus status = 3;
+  uint64 amount_minor_units = 4;
+  google.protobuf.Timestamp date_time = 5;
+}
+
+enum AdjustmentStatus {
+  ADJUSTMENT_PENDING = 0;
+  ADJUSTMENT_SUCCESS = 1;
+  ADJUSTMENT_ERROR = 2;
 }

--- a/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
+++ b/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
@@ -299,15 +299,18 @@ enum PaymentMethodType {
 }
 
 message Adjustment {
-  string adjustment_id = 1;
-  optional string adjustment_reference = 2;
-  AdjustmentStatus status = 3;
-  uint64 amount_minor_units = 4;
-  google.protobuf.Timestamp date_time = 5;
+  string adjustment_id = 1; // Unique identifier for this adjustment.
+  optional string adjustment_reference = 2; // Client's reference for the adjustment, if provided.
+  AdjustmentStatus status = 3; // Current status of the adjustment.
+  uint64 amount_minor_units = 4; // Amount of the adjustment in minor currency units.
+  google.protobuf.Timestamp created_at = 5; // Timestamp when the adjustment was created.
+  google.protobuf.Timestamp updated_at = 6; // Timestamp when the adjustment was last updated.
+  optional string psp_reference = 7; // PSP reference for this adjustment, if available.
 }
 
 enum AdjustmentStatus {
-  ADJUSTMENT_PENDING = 0;
-  ADJUSTMENT_SUCCESS = 1;
-  ADJUSTMENT_ERROR = 2;
+  ADJUSTMENT_STATUS_UNSPECIFIED = 0;
+  ADJUSTMENT_PENDING = 1;
+  ADJUSTMENT_SUCCESS = 2;
+  ADJUSTMENT_ERROR = 3;
 }

--- a/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
+++ b/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
@@ -221,8 +221,8 @@ message GetPreAuthorisationResponse {
   // The Kody-generated, secure token representing this specific authorisation.
   string pre_auth_id = 2;
 
-  // The client's order ID, if it was provided in the original request.
-  optional string order_id = 3;
+  // The PSP reference for this specific authorisation.
+  optional string psp_reference = 3;
 
   // The current status of the pre-authorisation.
   AuthStatus status = 4;
@@ -256,9 +256,6 @@ message GetPreAuthorisationResponse {
 
   // Any adjustments made to this pre-authorisation.
   repeated Adjustment adjustments = 14;
-
-  // The PSP reference for this specific authorisation.
-  optional string psp_reference = 15;
 }
 
 // --- Supporting Messages ---

--- a/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
+++ b/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
@@ -256,6 +256,9 @@ message GetPreAuthorisationResponse {
 
   // Any adjustments made to this pre-authorisation.
   repeated Adjustment adjustments = 14;
+
+  // The PSP reference for this specific authorisation.
+  optional string psp_reference = 15;
 }
 
 // --- Supporting Messages ---

--- a/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
+++ b/src/main/proto/com/kodypay/grpc/preauth/v1/preauth.proto
@@ -207,8 +207,10 @@ message ReleaseAuthorisationResponse {
 
 // Request to retrieve the details of an existing pre-authorisation.
 message GetPreAuthorisationRequest {
+  // The Kody Store ID.
+  string store_id = 1;
   // The Kody-generated, secure token representing the pre-authorisation.
-  string pre_auth_id = 1;
+  string pre_auth_id = 2;
 }
 
 // Response containing the full state of the pre-authorisation.


### PR DESCRIPTION
## **Associated JIRA tasks**

BAM-549: https://kodypay.atlassian.net/browse/BAM-549

## **What the change does.**

Add adjustments to the getPreauth response so that we can check the topup result after the timeout.

## **Does this change break backwards compatibility?.**

No, new feature
