### PR TITLE
feat(pci): rename DetokeniseCardRequest.idempotency_uuid to request_id

### DIFF
--- a/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
+++ b/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
@@ -67,7 +67,7 @@ message TokeniseCardResponse {
 
 message DetokeniseCardRequest {
   string store_id = 1; // Your Kody store id.
-  string idempotency_uuid = 2; // UUID v4 idempotency key for safe retries and audit deduplication.
+  string request_id = 2; // UUID v4 request identifier for log correlation and audit tracing. Does NOT provide execution-level idempotency.
   string payment_token = 3; // Same token namespace returned by TokeniseCard and accepted by token payment/pre-auth APIs.
   DetokeniseReason reason = 4; // Reason for retrieving the PAN.
 }


### PR DESCRIPTION
## Summary

Rename `DetokeniseCardRequest.idempotency_uuid` → `request_id` (field number 2 unchanged, wire-compatible).

## Why

The field `idempotency_uuid` in `DetokeniseCardRequest` is only used for log correlation and audit tracing — there is **no execution-level deduplication** on the server side. The name `idempotency_uuid` creates a misleading contract expectation that repeated calls with the same value would be idempotent.

Renaming to `request_id` clarifies the true semantics: it is a request tracking identifier, not an idempotency key.

## What Changes

- **Field renamed**: `idempotency_uuid` → `request_id` in `DetokeniseCardRequest`
- **Field number 2 preserved** → binary wire compatibility maintained
- **Comment updated** to clarify the field purpose
- **`TokeniseCardRequest.idempotency_uuid` is NOT changed** — it remains a true idempotency key backed by a database unique index

## Impact

- **Wire-compatible**: field number unchanged, no binary breakage
- **Source-level breaking**: callers using `setIdempotencyUuid()` / `getIdempotencyUuid()` must migrate to `setRequestId()` / `getRequestId()`. This contract is not yet publicly exposed — there are currently no external consumers affected.
- **No database migration** needed in downstream services
