### PR TITLE
feat(ci): auto-publish GitHub release on merge to main

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,64 @@
+name-template: 'v$RESOLVED_VERSION ⚙️'
+tag-template: 'v$RESOLVED_VERSION'
+tag-prefix: 'v'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  # What's Changed
+
+  $CHANGES
+
+categories:
+  - title: '🧠 Breaking changes'
+    label: 'type: breaking'
+  - title: '🚀 Features'
+    label: 'type: feature'
+  - title: '🐛 Bug Fixes'
+    label: 'type: bug'
+  - title: '🧰 Maintenance'
+    label: 'type: chore'
+  - title: '📖 Documentation'
+    label: 'type: docs'
+  - title: 'Other changes'
+  - title: '⬆️ Dependency Updates'
+    label: 'type: dependencies'
+    collapse-after: 3
+
+version-resolver:
+  patch:
+    labels:
+      - 'type: breaking'
+      - 'type: feature'
+      - 'type: bug'
+      - 'type: chore'
+      - 'type: docs'
+      - 'type: dependencies'
+      - 'type: security'
+  default: patch
+
+exclude-labels:
+  - 'skip-changelog'
+
+autolabeler:
+  - label: 'type: breaking'
+    branch:
+      - '/breaking\/.+/'
+      - '/major\/.+/'
+    title:
+      - '/breaking(\(\w+-?[0-9]*\))? *:'
+  - label: 'type: docs'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'type: chore'
+    branch:
+      - '/chore\/.+/'
+  - label: 'type: bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'type: feature'
+    branch:
+      - '/feat(ure)?\/.+/'
+    title:
+      - '/feat(ure)?(\(\w+-?[0-9]*\))? *:'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,19 @@
+name: release
+
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5
+        with:
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE }}


### PR DESCRIPTION
Add release-drafter (publish: true) triggered after a successful build on main, so the latest code is automatically tagged and released — same setup as the other kp-protocols-* repos (e.g. kp-protocols-grpc).