### PR TITLE
feat(pci)!: remove TokenUsage from TokeniseCardRequest

### DIFF
--- a/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
+++ b/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
@@ -27,13 +27,6 @@ message TokeniseCardRequest {
   string idempotency_uuid = 2; // UUID v4 idempotency key.
   CardDetails card = 3; // Full card data. holder_name is required for tokenisation input. Must never be logged.
   string payer_reference = 4; // Required non-PII payer reference. Carries the shopper identity binding for this token.
-
-  // Removed: the platform only supports merchant-initiated UnscheduledCardOnFile
-  // (no CVC is collected or stored, so CardOnFile cannot be charged), so the
-  // recurring processing model is fixed downstream and a caller-chosen usage
-  // was misleading. Field number and name are reserved to prevent reuse.
-  reserved 5;
-  reserved "usage";
 }
 
 message TokeniseCardResponse {

--- a/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
+++ b/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
@@ -14,13 +14,6 @@ service PciTokenService {
   rpc DetokeniseCard(DetokeniseCardRequest) returns (DetokeniseCardResponse);
 }
 
-enum TokenUsage {
-  TOKEN_USAGE_UNSPECIFIED = 0;
-  CARD_ON_FILE = 1;
-  UNSCHEDULED_CARD_ON_FILE = 2;
-  SUBSCRIPTION = 3;
-}
-
 enum DetokeniseReason {
   REASON_UNSPECIFIED = 0;
   MANUAL_OPERATION = 1;
@@ -34,7 +27,13 @@ message TokeniseCardRequest {
   string idempotency_uuid = 2; // UUID v4 idempotency key.
   CardDetails card = 3; // Full card data. holder_name is required for tokenisation input. Must never be logged.
   string payer_reference = 4; // Required non-PII payer reference. Carries the shopper identity binding for this token.
-  TokenUsage usage = 5; // Required future-use classification. Maps to the downstream recurring processing model.
+
+  // Removed: the platform only supports merchant-initiated UnscheduledCardOnFile
+  // (no CVC is collected or stored, so CardOnFile cannot be charged), so the
+  // recurring processing model is fixed downstream and a caller-chosen usage
+  // was misleading. Field number and name are reserved to prevent reuse.
+  reserved 5;
+  reserved "usage";
 }
 
 message TokeniseCardResponse {


### PR DESCRIPTION
## **Associated JIRA tasks**

N/A

## **What the change does.**

Removes the `TokenUsage` parameter from `pci.v1.TokeniseCardRequest`.

The platform can only charge stored tokens as merchant-initiated `UnscheduledCardOnFile`: no CVC is collected or stored (so `CardOnFile`, which Adyen requires CVC for at payment time, cannot be honoured), and the downstream payment path fixes the recurring processing model regardless. A caller-chosen `TokenUsage` therefore advertised options the system cannot fulfil.

Because this contract is not yet published or consumed, it is removed directly rather than kept as a single-valued / misleading parameter:

- remove `TokenUsage usage = 5` from `TokeniseCardRequest`
- remove the `enum TokenUsage`
- `reserved 5;` + `reserved "usage";` so the number/name cannot be silently reused

If `CardOnFile`/`Subscription` support is ever added (requires a CVC/SCA-capable customer-present payment flow), a new field can be introduced additively.

Consumer change: kp-pan-api drops its `usage` handling and pins the tokenisation recurring processing model to `UnscheduledCardOnFile` (separate PR, bumps to `kody-clientsdk-kotlin:1.8.2`).

## **Does this change break backwards compatibility?.**

Source-level: yes — generated `setUsage()`/`getUsage()` and `TokenUsage` are removed, so any source referencing them stops compiling. There are **no consumers yet** (TokeniseCard is unpublished/unused), so there is no real-world break. Wire-level: the field is removed and its number reserved, so no tag reuse/cross-talk.

Suggested label: `type: breaking` (release-drafter still resolves a patch bump → expected `v1.8.2`).