### PR TITLE
feat(pci): add optional CardField fields selector to DetokeniseCard

### DIFF
--- a/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
+++ b/src/main/proto/com/kodypay/grpc/pci/v1/pci.proto
@@ -22,6 +22,17 @@ enum DetokeniseReason {
   VERIFICATION = 4;
 }
 
+// Selects which card fields DetokeniseCard should return. EXPIRY covers both
+// expiry_month and expiry_year. Optional and backward-compatible: when the
+// caller sends no fields, all fields are returned (the original behaviour);
+// when fields are specified, only those are returned (data minimisation).
+enum CardField {
+  CARD_FIELD_UNSPECIFIED = 0;
+  CARD_FIELD_NUMBER = 1;       // PAN
+  CARD_FIELD_EXPIRY = 2;       // expiry_month + expiry_year
+  CARD_FIELD_HOLDER_NAME = 3;  // cardholder name
+}
+
 message TokeniseCardRequest {
   string store_id = 1; // Your Kody store id.
   string idempotency_uuid = 2; // UUID v4 idempotency key.
@@ -62,6 +73,7 @@ message DetokeniseCardRequest {
   string request_id = 2; // UUID v4 request identifier for log correlation and audit tracing. Does NOT provide execution-level idempotency.
   string payment_token = 3; // Same token namespace returned by TokeniseCard and accepted by token payment/pre-auth APIs.
   DetokeniseReason reason = 4; // Reason for retrieving the PAN.
+  repeated CardField fields = 5; // Optional. Which card fields to return. Empty = all fields (original behaviour); otherwise only the requested fields.
 }
 
 message DetokeniseCardResponse {


### PR DESCRIPTION
## **Associated JIRA tasks**

N/A

## **What the change does.**

Adds a `repeated CardField fields` selector (+ `CardField` enum) to `pci.v1.DetokeniseCardRequest`, so a caller can request only the card fields it needs.

- **empty `fields` = all fields returned** (the original behaviour) — old-SDK clients are unaffected
- **non-empty `fields` = only the requested fields returned** (data minimisation)

This lets one `DetokeniseCard` contract serve both the internal card-retrieval need (`number` + `expiry`) and the external Shiji need (`number` + `expiry` + `holder_name`). The operator identity for internal audit comes from gateway-injected (kp-token) metadata, **not** the proto, so no operator field is added.

## **Does this change break backwards compatibility?.**

No. It is purely additive: a new optional field (`fields = 5`) + a new enum. Old clients that don't send `fields` get the same full card as before (server treats empty as "all fields"). Wire-compatible. Tightening "require fields" for a population is a later, coordinated server-side policy, not part of this contract change.

Consumer change (kp-pan-api: honour `fields`, and record `operator` from the kp-token email header for internal-platform requests) is a separate PR that bumps to this release.