### PR TITLE
feat(ecom): support tokenise_card on InitiatePayment for non-zero amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this repository will be documented in this file.
 
+## 2026-07-16
+
+### Changed
+- Un-deprecated `PaymentInitiationRequest.tokenise_card` in `com/kodypay/grpc/ecom/v1/ecom.proto` and added `payer_reference` (field 17) and `recurring_processing_model` (field 18), mirroring the equivalent fields on `CreateTokenRequest`. This lets `InitiatePayment` tokenise the card used for a real, non-zero-amount payment in one call, instead of requiring a separate zero-amount `CreateCardToken` request first. `payer_reference` is required by the server when `tokenise_card` is true (see kp-core's mapping change for the request-level validation).
+
 ## 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this repository will be documented in this file.
 ### Changed
 - Un-deprecated `PaymentInitiationRequest.tokenise_card` in `com/kodypay/grpc/ecom/v1/ecom.proto` and added `payer_reference` (field 17) and `recurring_processing_model` (field 18), mirroring the equivalent fields on `CreateTokenRequest`. This lets `InitiatePayment` tokenise the card used for a real, non-zero-amount payment in one call, instead of requiring a separate zero-amount `CreateCardToken` request first. `payer_reference` is required by the server when `tokenise_card` is true (see kp-core's mapping change for the request-level validation).
 
+### Added
+- Added `card_expiry_date` (field 12, optional string, format `MM/yyyy`) to `GetCardTokenResponse.Response` in `com/kodypay/grpc/ecom/v1/ecom.proto`. The tokenised card's expiry date was already stored server-side but never exposed on this response; this closes that gap for OPI's Pay-by-Link `TransToken` flow, which requires an `ExpiryDate` alongside the token.
+
 ## 2026-05-15
 
 ### Added

--- a/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
+++ b/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
@@ -354,6 +354,7 @@ message GetCardTokenResponse {
     string payment_method_variant = 9; // Card variant, e.g. mccredit, mcdebit, visa, visadebit, etc.
     string funding_source = 10; // Funding source of the card, e.g. CREDIT, DEBIT, PREPAID, etc. (aligns with PaymentCard.funding_source)
     string card_last_4_digits = 11; // Last four digits of the card number (aligns with PaymentCard.card_last_4_digits)
+    optional string card_expiry_date = 12; // Expiry date of the tokenised card, format: MM/yyyy
   }
 
   enum CardTokenStatus {

--- a/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
+++ b/src/main/proto/com/kodypay/grpc/ecom/v1/ecom.proto
@@ -35,11 +35,13 @@ message PaymentInitiationRequest {
   optional string payer_email_address = 9; // We recommend that you provide this data, as it is used in velocity fraud checks. Required for 3D Secure 2 transactions.
   optional string payer_ip_address = 10; // The payer IP address used for risk checks, also required for 3D Secure 2 transactions.
   optional string payer_locale = 11; // The language code and country code to specify the language to display the payment pages. It will default to en_GB if not set.
-  optional bool tokenise_card = 12 [deprecated = true]; // defaults false
+  optional bool tokenise_card = 12; // If true, tokenises the card used for this payment so it can be reused via PayWithCardToken. Requires payer_reference to be set. Defaults to false.
   optional ExpirySettings expiry = 13; // Nested message for expiry settings
   optional CaptureOptions capture_options = 14; // Optional capture settings
   optional bool is_pay_by_bank_accepted = 15; // Whether the payer can pay via pay by bank (Kody store must have pay by bank configured)
   repeated PaymentMethods accepts_only = 16; // An inclusion list of accepted payment methods. If empty, all payment methods are accepted.
+  optional string payer_reference = 17; // The payer for whom the token is being created. This can be a user ID or any unique identifier you use to track users. Required when tokenise_card is true.
+  optional RecurringProcessingModel recurring_processing_model = 18; // The recurring model to use when tokenise_card is true. Can be 'Subscription', 'UnscheduledCardOnFile' or 'CardOnFile'.
 
   message ExpirySettings {
     bool show_timer = 1; // Display a countdown timer to the user in the payment page, default is false


### PR DESCRIPTION
## **Associated JIRA tasks**

No associated JIRA ticket.

## **What the change does.**

### Change 1 — un-deprecate `InitiatePayment` tokenise support (original scope)

Un-deprecates `PaymentInitiationRequest.tokenise_card` in `com/kodypay/grpc/ecom/v1/ecom.proto` and adds two fields mirroring `CreateTokenRequest`: `payer_reference` (field 17, `optional string`) and `recurring_processing_model` (field 18, `optional RecurringProcessingModel`, reusing the existing top-level enum, no new enum introduced).

This lets a single `InitiatePayment` call tokenise the card used for a real, non-zero-amount payment, instead of requiring a separate zero-amount `CreateCardToken` request first.

### Change 2 — `card_expiry_date` on `GetCardTokenResponse` (added while designing the OPI Pay-by-Link consumer of Change 1)

Adds `card_expiry_date` (field 12, `optional string`, format `MM/yyyy`) to `GetCardTokenResponse.Response`. The tokenised card's expiry date is already stored server-side (populated via the token lifecycle event, including for the Pay-by-Link tokenisation path this PR enables) but was never exposed on this response. OPI's Pay-by-Link TransType 57 response is required to return `ExpiryDate` alongside `TransToken` for an Approved transaction (OPI V26.1 Table 124) — this was the one protocol gap in that otherwise-already-wired chain (see the linked RCA/PRD for the full analysis of why no new RPC is needed).

## **Does this change break backwards compatibility?.**

No. 
